### PR TITLE
Updated mfalib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,11 +240,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1030,7 +1027,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 name = "mfalib"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "rust-crypto",
 ]
 

--- a/authgen/src/main.rs
+++ b/authgen/src/main.rs
@@ -4,8 +4,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static _SAMPLE_BASE64_USER_SECRET: &str = "gzBsRiEnc3Kwc/26S3gklyz5M4UUOztqbO4pbhtgDi4=";
 
-const CODE_TIME: u64 = 30; // seconds
-
 fn main() {
     let user_secret = &general_purpose::STANDARD
     .decode(_SAMPLE_BASE64_USER_SECRET)
@@ -28,7 +26,7 @@ fn main() {
     .expect("Failed to get current time. Is your system time set to before 1/1/1970?")
     .as_secs();
 
-    let time_left = 30 - (current_unix_time % CODE_TIME);
+    let time_left = 30 - (current_unix_time % mfalib::CODE_TIME);
 
     println!("Code: {}", mfa_code);
     println!("This code will last for the next {} seconds.", time_left);

--- a/authgen/src/main.rs
+++ b/authgen/src/main.rs
@@ -1,4 +1,5 @@
 use mfalib;
+use std::env;
 use base64::{Engine as _, engine::general_purpose};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -19,6 +20,13 @@ fn main() {
         // I promise this won't fail
         .unwrap()
     );
+
+    // Read command-line arguments
+    let args: Vec<_> = env::args().collect();
+    if args.len() > 1 && (args[1] == "-q" || args[1] == "--quiet") {
+        println!("{}",mfa_code);
+        return;
+    }
 
     // number of seconds since January 1, 1970
     let current_unix_time = SystemTime::now()

--- a/authgen/src/main.rs
+++ b/authgen/src/main.rs
@@ -1,7 +1,10 @@
 use mfalib;
 use base64::{Engine as _, engine::general_purpose};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 static _SAMPLE_BASE64_USER_SECRET: &str = "gzBsRiEnc3Kwc/26S3gklyz5M4UUOztqbO4pbhtgDi4=";
+
+const CODE_TIME: u64 = 30; // seconds
 
 fn main() {
     let user_secret = &general_purpose::STANDARD
@@ -11,12 +14,22 @@ fn main() {
     let mfa_code = mfalib::gen_mfa(
         user_secret
         // &Vec<u8> -> [u8]
-        .as_slice()
+        .as_slice()[..32]
         // [u8] -> [u8; 32]
+        // we can guarantee this will work thanks to the previous [..32]
         .try_into()
         // I promise this won't fail
         .unwrap()
     );
 
+    // number of seconds since January 1, 1970
+    let current_unix_time = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("Failed to get current time. Is your system time set to before 1/1/1970?")
+    .as_secs();
+
+    let time_left = 30 - (current_unix_time % CODE_TIME);
+
     println!("Code: {}", mfa_code);
+    println!("This code will last for the next {} seconds.", time_left);
 }

--- a/mfalib/Cargo.toml
+++ b/mfalib/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 rust-crypto = "^0.2"
-chrono = "0.4.23"

--- a/mfalib/src/lib.rs
+++ b/mfalib/src/lib.rs
@@ -4,7 +4,7 @@ use crypto::{md5::Md5, digest::Digest};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const MFA_CODE_LENGTH: usize = 6;
-const CODE_TIME: u64 = 30; // seconds
+pub const CODE_TIME: u64 = 30; // seconds
 
 pub fn gen_mfa(_user_secret: &[u8; 32]) -> String {
     // MD5 can be apparently cracked by a cell phone in 30s

--- a/mfalib/src/lib.rs
+++ b/mfalib/src/lib.rs
@@ -1,29 +1,31 @@
 extern crate crypto;
 
-use chrono;
-use crypto::md5::Md5;
-use crypto::digest::Digest;
+use crypto::{md5::Md5, digest::Digest};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const MFA_CODE_LENGTH: usize = 6;
+const CODE_TIME: u64 = 30; // seconds
 
 pub fn gen_mfa(_user_secret: &[u8; 32]) -> String {
     // MD5 can be apparently cracked by a cell phone in 30s
     // Hopefully we generate our code after 30s!
     let mut super_secure_md5 = Md5::new();
 
-    // current UTC time
-    // we simply don't put the seconds in the string
-    let time_in_england = chrono::offset::Utc::now();
-    let formatted_bad_teeth_time = time_in_england
-        .format("%Y%m%d%H%M")
-        .to_string();
+    // number of seconds since January 1, 1970: u64
+    let mut current_unix_time = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("Failed to get current time. Is your system time set to before 1/1/1970?")
+    .as_secs();
+
+    // round to nearest CODE_TIME seconds
+    current_unix_time -= current_unix_time % CODE_TIME;
 
     // create new vector which we will eventually feed to the md5 hasher
     let mut md5_input: Vec<u8> = Vec::new();
     // add the user secret to the vector
     md5_input.extend(_user_secret.iter().copied());
     // add the current time to the vector
-    md5_input.extend(formatted_bad_teeth_time.as_bytes());
+    md5_input.extend(current_unix_time.to_string().as_bytes());
 
     // hash string
     super_secure_md5.input(&md5_input);


### PR DESCRIPTION
Changes:
- Timer now resets after 30 seconds
- `authlib` now tells you how many seconds are left with your current code
- Added a `-q` or `--quiet` switch to `authlib` which causes the binary to simply print the current MFA code and return
- Removed silly `chrono` dependency